### PR TITLE
[add] Dialog system

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -8,9 +8,20 @@
 
 config_version=4
 
-_global_script_classes=[  ]
+_global_script_classes=[ {
+"base": "Control",
+"class": "Dialog",
+"language": "GDScript",
+"path": "res://sources/dialog/Dialog.gd"
+}, {
+"base": "Control",
+"class": "SpeechBubble",
+"language": "GDScript",
+"path": "res://sources/dialog/SpeechBubble.gd"
+} ]
 _global_script_class_icons={
-
+"Dialog": "",
+"SpeechBubble": ""
 }
 
 [application]

--- a/sources/TestScene.gd
+++ b/sources/TestScene.gd
@@ -1,0 +1,4 @@
+"""
+Simple testscene, not meant to be commited!
+"""
+extends Node2D

--- a/sources/TestScene.tscn
+++ b/sources/TestScene.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://sources/TestScene.gd" type="Script" id=1]
+
+[node name="TestScene" type="Node2D"]
+script = ExtResource( 1 )

--- a/sources/dialog/Dialog.gd
+++ b/sources/dialog/Dialog.gd
@@ -1,0 +1,5 @@
+"""
+handle any monolog or dialog between one or multiple entities
+"""
+extends Control
+class_name Dialog

--- a/sources/dialog/Dialog.gd
+++ b/sources/dialog/Dialog.gd
@@ -3,3 +3,70 @@ handle any monolog or dialog between one or multiple entities
 """
 extends Control
 class_name Dialog
+signal dialog_start
+signal dialog_next
+signal dialog_end
+
+export (NodePath) var bubble_path
+
+var bubble
+
+var lines = []
+var current_line = 0
+
+
+func _ready() -> void:
+	bubble = get_node(bubble_path)
+
+	assert(bubble)
+	assert(bubble.connect("bubble_end", self, "on_bubble_end") == OK)
+
+	# Get lines
+	for child in get_children():
+		assert(child is DialogLine)
+
+		lines.append(child)
+
+
+func start() -> void:
+	"""
+	Start the dialog
+	"""
+	visible = true
+	current_line = -1
+
+	emit_signal("dialog_start")
+
+	next()
+
+
+func next() -> void:
+	"""
+	Display next line of dialog
+	"""
+	current_line += 1
+
+	if current_line >= lines.size():
+		end()
+		return
+
+	var next_line = lines[current_line]
+	if next_line.thinking:
+		bubble.think(next_line.content)
+	else:
+		bubble.say(next_line.content)
+
+	emit_signal("dialog_next")
+
+
+func end() -> void:
+	"""
+	Ends the dialog
+	"""
+	visible = false
+
+	emit_signal("dialog_end")
+
+
+func on_bubble_end():
+	next()

--- a/sources/dialog/Dialog.tscn
+++ b/sources/dialog/Dialog.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://sources/dialog/Dialog.gd" type="Script" id=1]
+
+[node name="Dialog" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/sources/dialog/DialogLine.gd
+++ b/sources/dialog/DialogLine.gd
@@ -1,0 +1,10 @@
+"""
+Stores one line of dialog
+"""
+extends Node
+class_name DialogLine
+
+
+export (String) var content		# What is being said
+export (NodePath) var who		# Who said that? none for narrator
+export (bool) var thinking		# Thinking or said out loud?

--- a/sources/dialog/DialogLine.tscn
+++ b/sources/dialog/DialogLine.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://sources/dialog/DialogLine.gd" type="Script" id=1]
+
+[node name="DialogLine" type="Node"]
+script = ExtResource( 1 )

--- a/sources/dialog/SpeechBubble.gd
+++ b/sources/dialog/SpeechBubble.gd
@@ -7,18 +7,29 @@ signal bubble_start		# Start displaying
 signal bubble_next		# Show next line
 signal bubble_end		# Nothing more to say
 
-# Who is speaking? Empty for narrator
-export (NodePath) var who
-
-# Is this a thought?
-export (bool) var thinking
 
 onready var label := $PanelContainer/Content as Label
 
 
 func say(content: String) -> void:
 	"""
-	Set the content of the bubble
+	Text said out loud by the character
+	"""
+	# TODO: Different style?
+	start(content)
+
+
+func think(content: String) -> void:
+	"""
+	Thought of a character
+	"""
+	# TODO: Different style?
+	start(content)
+
+
+func start(content: String) -> void:
+	"""
+	Displays the given text
 	"""
 	label.text = content
 	label.lines_skipped = 0

--- a/sources/dialog/SpeechBubble.gd
+++ b/sources/dialog/SpeechBubble.gd
@@ -1,0 +1,53 @@
+"""
+Handles the speech bubble of a specific character
+"""
+extends Control
+class_name SpeechBubble
+signal bubble_start		# Start displaying
+signal bubble_next		# Show next line
+signal bubble_end		# Nothing more to say
+
+# Who is speaking? Empty for narrator
+export (NodePath) var who
+
+# Is this a thought?
+export (bool) var thinking
+
+onready var label := $PanelContainer/Content as Label
+
+
+func say(content: String) -> void:
+	"""
+	Set the content of the bubble
+	"""
+	label.text = content
+	label.lines_skipped = 0
+
+	visible = true
+
+	emit_signal("bubble_start")
+
+
+func next() -> void:
+	"""
+	Displays the next lines
+	"""
+	var line_shown = label.lines_skipped + label.max_lines_visible
+	if line_shown < label.get_line_count():
+		label.lines_skipped += label.max_lines_visible
+		emit_signal("bubble_next")
+	else:
+		end()
+
+
+func end() -> void:
+	"""
+	Bubble is hidden
+	"""
+	visible = false
+	emit_signal("bubble_end")
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_accept"):
+		next()

--- a/sources/dialog/SpeechBubble.tscn
+++ b/sources/dialog/SpeechBubble.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://sources/dialog/SpeechBubble.gd" type="Script" id=1]
+
+[node name="SpeechBubble" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+margin_right = 400.0
+margin_bottom = 100.0
+rect_min_size = Vector2( 400, 100 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Content" type="Label" parent="PanelContainer"]
+margin_left = 7.0
+margin_top = 24.0
+margin_right = 393.0
+margin_bottom = 76.0
+custom_constants/line_spacing = 5
+text = "line1: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+line2: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+line3: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+line4: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+clip_text = true
+max_lines_visible = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}


### PR DESCRIPTION
Adds multiple scenes to handle basic monolog/dialogs/polylogs

![DeepinScreenshot_select-area_20200216120847](https://user-images.githubusercontent.com/1417856/74603579-2d727580-50b5-11ea-9db7-05b25a069e8a.png)

Adds any number of Dialog into the level. For each of them populates them with children DialogLine. Sequential order for dialog

Call start() on any of the Dialog nodes to trigger the dialog
They need a SpeechBubble to display stuff so add that to the scene too

Fix #8 